### PR TITLE
Copying multiple files needs trailing slash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM rust
 
 WORKDIR /app
-COPY ./Cargo.* /app
+COPY ./Cargo.* /app/
 COPY ./src/ /app/src
 RUN cargo build --release
 ENTRYPOINT [ "/app/target/release/rust-stakeholder" ]


### PR DESCRIPTION
When copying multiple files into a docker container you need to add a trailing slash to the destination dir. Otherwise the docker build will fail with an error.