### PR TITLE
Implement multistage container build and publish to GitHub registry (ghcr.io)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,60 @@
+# based on https://docs.github.com/en/actions/use-cases-and-examples/publishing-packages/publishing-docker-images
+name: Create and publish a Docker image
+
+# Configures this workflow to run every time a change is pushed to the branch called `release`.
+on:
+  push:
+    branches: ['main', 'master']
+
+# Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+# There is a single job in this workflow. It's configured to run on the latest available version of Ubuntu.
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+      #
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      # Uses the `docker/login-action` action to log in to the Container registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
+      # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see [Usage](https://github.com/docker/build-push-action#usage) in the README of the `docker/build-push-action` repository.
+      # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+      
+      # This step generates an artifact attestation for the image, which is an unforgeable statement about where and how it was built. It increases supply chain security for people who consume the image. For more information, see [Using artifact attestations to establish provenance for builds](/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds).
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
+      

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+.idea
 /target

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,11 @@
-FROM rust
-
+# Stage 1 - Build rust application
+FROM rust:latest as builder
 WORKDIR /app
-COPY ./Cargo.* /app/
-COPY ./src/ /app/src
+COPY . .
 RUN cargo build --release
-ENTRYPOINT [ "/app/target/release/rust-stakeholder" ]
+
+# Stage 2, final image
+FROM debian:latest
+WORKDIR /app
+COPY --from=builder /app/target/release/rust-stakeholder /usr/local/bin
+ENTRYPOINT ["rust-stakeholder"]

--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ Remember, it's not about your actual contribution to the codebase, it's about ho
 - 👥 **Imaginary team activity**: Pretend your invisible friends are sending you important pull requests
 - 🎮 **Domain chameleon**: Switch between backend, frontend, blockchain and 7 other domains faster than you can say "full-stack developer"
 
+## Quick run
+
+```bash
+docker run -t --rm ghcr.io/giacomo-b/rust-stakeholder:master
+```
+
 ## Installation
 
 ```
@@ -42,27 +48,6 @@ Or build from source (warning: might involve actual programming):
 git clone https://github.com/giacomo-b/rust-stakeholder.git
 cd rust-stakeholder
 cargo build --release # Look at you doing real developer things!
-```
-
-## Docker
-Build image
-
-```bash
-docker build -t rust-stakeholder .
-```
-
-Usage
-
-Basic usage:
-
-```
-docker run -t --rm rust-stakeholder
-```
-
-All commands below can be used through:
-
-```bash
-docker run -t --rm rust-stakeholder [arguments]
 ```
 
 ## Usage for career advancement

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,3 @@
 [toolchain]
 channel = "stable"
 components = [ "rustfmt", "rust-src", "clippy" ]
-targets = ["x86_64-unknown-linux-gnu"]


### PR DESCRIPTION
Fake your developer skills even harder by not even having to compile rust code or even use git to checkout this repository. With this pull request included, you just need docker preinstalled, that's it.

The following command will get you up and running:
```bash
docker run -t --rm ghcr.io/giacomo-b/rust-stakeholder:master
```
Please be aware, that you need to merge this pull request, so the first container image can be published at ghcr.io/**giacomo-b**. I have tested the workflow on my fork and it works just fine.

```bash
docker run -t --rm ghcr.io/freddyfunk/rust-stakeholder:master
```

I could have implemented a better container image tagging system including a _latest_ tag, but I think it is funnier to embrace the satire and use _master_ as the container tag.