### PR TITLE
Add "fake error" when program terminates

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -9,4 +9,5 @@ pub struct SessionConfig {
     pub minimal_output: bool,
     pub team_activity: bool,
     pub framework: String,
+    pub fake_error: bool,
 }

--- a/src/generators/fake_error.rs
+++ b/src/generators/fake_error.rs
@@ -2,7 +2,7 @@
 use rand::prelude::*;
 
 // Returns a file type for the fake error
-pub fn FE_FILE_EXTEND() -> String {
+pub fn fe_file_extend() -> String {
     let mut rng = rand::rng();
 
     let fe = [".c", ".cpp", ".js", ".rs", ".cs", ".py"];
@@ -15,7 +15,7 @@ pub fn FE_FILE_EXTEND() -> String {
 }
 
 // Returns a random piece of code with an error in it
-pub fn FE_CODE_TEXT() -> String {
+pub fn fe_code_text() -> String {
     let mut rng = rand::rng();
 
     let ft = [
@@ -34,15 +34,15 @@ pub fn FE_CODE_TEXT() -> String {
 }
 
 // Get the full fake error
-pub fn FE_GET_ERRORS() -> String {
+pub fn fe_get_errors() -> String {
     let mut rng = rand::rng();
 
     let mut nums: Vec<u8> = (1..100).collect();
     nums.shuffle(&mut rng);
     let line_num = nums[0];
 
-    let file = FE_FILE_EXTEND();
-    let code = FE_CODE_TEXT();
+    let file = fe_file_extend();
+    let code = fe_code_text();
 
     let error_text = format!("Compiler Error on line {} in file \"code{}\"\n   {}   {}\nVariable \"varable\" has not been declared!",line_num,file,line_num,code);
     return error_text;

--- a/src/generators/fake_error.rs
+++ b/src/generators/fake_error.rs
@@ -33,7 +33,17 @@ pub fn FE_CODE_TEXT() -> String {
     }
 }
 
-// "Variable \"varable\" has not been declared!";
+// Get the full fake error
+pub fn FE_GET_ERRORS() -> String {
+    let mut rng = rand::rng();
 
+    let mut nums: Vec<u8> = (1..100).collect();
+    nums.shuffle(&mut rng);
+    let line_num = nums[0];
 
+    let file = FE_FILE_EXTEND();
+    let code = FE_CODE_TEXT();
 
+    let error_text = format!("Compiler Error on line {} in file \"code{}\"\n   {}   {}\nVariable \"varable\" has not been declared!",line_num,file,line_num,code);
+    return error_text;
+}

--- a/src/generators/fake_error.rs
+++ b/src/generators/fake_error.rs
@@ -1,0 +1,39 @@
+// Import rand to randomize file extension and code
+use rand::prelude::*;
+
+// Returns a file type for the fake error
+pub fn FE_FILE_EXTEND() -> String {
+    let mut rng = rand::rng();
+
+    let fe = [".c", ".cpp", ".js", ".rs", ".cs", ".py"];
+
+    if let Some(ext) = fe.choose(&mut rng) {
+        ext.to_string()
+    } else {
+        String::from(".rs") // fallback if array is empty (shouldn't happen here)
+    }
+}
+
+// Returns a random piece of code with an error in it
+pub fn FE_CODE_TEXT() -> String {
+    let mut rng = rand::rng();
+
+    let ft = [
+        "std::cout << varable;",
+        "print(varable)",
+        "debug.log(varable);",
+        "Console.WriteLine(varable);",
+        "println!(varable);"
+    ];
+
+    if let Some(ext) = ft.choose(&mut rng) {
+        ext.to_string()
+    } else {
+        String::from("varable") // fallback if array is empty (shouldn't happen here)
+    }
+}
+
+// "Variable \"varable\" has not been declared!";
+
+
+

--- a/src/generators/mod.rs
+++ b/src/generators/mod.rs
@@ -4,3 +4,4 @@ pub mod jargon;
 pub mod metrics;
 pub mod network_activity;
 pub mod system_monitoring;
+pub mod fake_error;

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ mod generators;
 mod types;
 use types::{Complexity, DevelopmentType, JargonLevel};
 
-/// A CLI tool that generates impressive-looking terminal output when stakeholders walk by
+/// A CLI tool that generates impressive-looking terminal output when stakeholders walk by alla
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 struct Args {
@@ -58,6 +58,10 @@ struct Args {
     /// Simulate a specific framework usage
     #[arg(short = 'F', long, default_value = "")]
     framework: String,
+
+    /// Create fake errors when session terminates
+    #[arg(short = 'e', long, default_value_t = false)]
+    fakeerror: bool,
 }
 
 fn main() {
@@ -72,6 +76,7 @@ fn main() {
         minimal_output: args.minimal,
         team_activity: args.team,
         framework: args.framework,
+        fake_error: args.fakeerror,
     };
 
     let running = Arc::new(AtomicBool::new(true));

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,10 @@ use std::{
     time::{Duration, Instant},
 };
 
+use crate::generators::{
+    fake_error
+};
+
 mod activities;
 mod config;
 mod display;
@@ -150,5 +154,10 @@ fn main() {
     }
 
     let _ = term.clear_screen();
+
+    if config.fake_error {
+        println!("{}", "This is a fake error!".bright_red());
+    }
+
     println!("{}", "Session terminated.".bright_green());
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -156,7 +156,7 @@ fn main() {
     let _ = term.clear_screen();
 
     if config.fake_error {
-        println!("{}", fake_error::FE_GET_ERRORS().bright_red());
+        println!("{}", fake_error::fe_get_errors().bright_red());
     }
 
     println!("{}", "Session terminated.".bright_green());

--- a/src/main.rs
+++ b/src/main.rs
@@ -156,7 +156,7 @@ fn main() {
     let _ = term.clear_screen();
 
     if config.fake_error {
-        println!("{}", "This is a fake error!".bright_red());
+        println!("{}", fake_error::FE_GET_ERRORS().bright_red());
     }
 
     println!("{}", "Session terminated.".bright_green());

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ mod generators;
 mod types;
 use types::{Complexity, DevelopmentType, JargonLevel};
 
-/// A CLI tool that generates impressive-looking terminal output when stakeholders walk by alla
+/// A CLI tool that generates impressive-looking terminal output when stakeholders walk by
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 struct Args {


### PR DESCRIPTION
This feature allows the user to add a "fake error" before the "Session terminated." text that looks like a generic compiler error.

The feature picks a random file type and a random piece of code that would create an error

The feature can be turned on with either "-f" or "--fakeerror"

<img width="674" height="18" alt="image" src="https://github.com/user-attachments/assets/a924876d-3f95-49bb-9bba-ba1ab05f06f4" />

<img width="375" height="93" alt="image" src="https://github.com/user-attachments/assets/b5bc8b88-66d6-428f-a959-6b0e4cdcbf49" />

